### PR TITLE
Add resume queue option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.0.0
+
+### Added
+
+- Queue driver `resume` option _(can be used for periodic connection reloading)_
+
+### Changed
+
+- `Queue` class constructor signature
+
 ## v1.0.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - `Queue` class constructor signature
+- Option `sleep` for `queue:work` command marked as unused
+- Option `timeout` for `queue:work` now `-1` by default. It means next - by default used timeout value from configuration file, but this value can be overridden by passing `--timeout` option with `0..+n` value
 
 ## v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For jobs delaying you also should install [`rabbitmq-delayed-message-exchange`][
 Require this package with composer using the following command:
 
 ```shell
-$ composer require avto-dev/amqp-rabbit-laravel-queue "^1.0"
+$ composer require avto-dev/amqp-rabbit-laravel-queue "^2.0"
 ```
 
 > Installed `composer` is required ([how to install composer][getcomposer]). Also you need to fix the major version of package.
@@ -51,6 +51,8 @@ Laravel 5.5 and above uses Package Auto-Discovery, so doesn't require you to man
 After that you should modify your configuration files:
 
 ### `./config/rabbitmq.php`
+
+RabbitMQ queues and exchanges configuration:
 
 ```php
 <?php
@@ -119,6 +121,8 @@ return [
 
 ### `./config/queue.php`
 
+Laravel queue settings: 
+
 ```php
 <?php
 
@@ -142,6 +146,7 @@ return [
             'queue_id'            => 'jobs',
             'delayed_exchange_id' => 'delayed-jobs',
             'timeout'             => 0, // The timeout is in milliseconds
+            'resume'              => false, // Resume consuming when timeout is over
         ],
     ],
 
@@ -153,6 +158,8 @@ return [
     ],
 ];
 ```
+
+> `resume` can be used with non-zero `timeout` value for periodic connection reloading _(for example, if you set `'timeout' => 30000` and `'resume' => true`, queue worker will unsubscribe and subscribe back to the queue every 30 seconds **without** process exiting)_.
 
 You can remove `delayed_exchange_id` for disabling delayed jobs feature.
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ return [
             'connection'          => 'rabbit-default',
             'queue_id'            => 'jobs',
             'delayed_exchange_id' => 'delayed-jobs',
-            'timeout'             => 0, // The timeout is in milliseconds
-            'resume'              => false, // Resume consuming when timeout is over
+            'timeout'             => (int) env('QUEUE_TIMEOUT', 0), // The timeout is in milliseconds
+            'resume'              => (bool) env('QUEUE_RESUME', false), // Resume consuming when timeout is over
         ],
     ],
 

--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -21,6 +21,16 @@ class WorkCommand extends \Illuminate\Queue\Console\WorkCommand
      */
     public function __construct(Worker $worker)
     {
+        // Override default timeout value ('60' to '-1')
+        $this->signature = (string) \preg_replace(
+            '~(\-\-timeout=)\d+~', '$1-1', $this->signature
+        );
+
+        // Mark 'sleep' option as not used
+        $this->signature = (string) \preg_replace(
+            '~(\-\-sleep.*)\}~', '$1 <options=bold>(not used)</> }', $this->signature
+        );
+
         parent::__construct($worker);
     }
 

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -75,11 +75,12 @@ class Connector implements \Illuminate\Queue\Connectors\ConnectorInterface
         $connection = $this->connections->make($config['connection']);
         $queue      = $this->queues->make($config['queue_id']);
         $timeout    = (int) ($config['timeout'] ?? 0);
+        $resume     = (bool) ($config['resume'] ?? false); // !!!!
 
         $delayed_exchange = isset($config['delayed_exchange_id'])
             ? $this->exchanges->make($config['delayed_exchange_id'])
             : null;
 
-        return new Queue($this->container, $connection, $queue, $timeout, $delayed_exchange);
+        return new Queue($this->container, $connection, $queue, $timeout, $resume, $delayed_exchange);
     }
 }

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -75,7 +75,7 @@ class Connector implements \Illuminate\Queue\Connectors\ConnectorInterface
         $connection = $this->connections->make($config['connection']);
         $queue      = $this->queues->make($config['queue_id']);
         $timeout    = (int) ($config['timeout'] ?? 0);
-        $resume     = (bool) ($config['resume'] ?? false); // !!!!
+        $resume     = (bool) ($config['resume'] ?? false);
 
         $delayed_exchange = isset($config['delayed_exchange_id'])
             ? $this->exchanges->make($config['delayed_exchange_id'])

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -67,7 +67,7 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
         $this->queue            = $queue;
         $this->timeout          = \max(0, $timeout);
         $this->delayed_exchange = $delayed_exchange;
-        $this->resume = $resume;
+        $this->resume           = $resume;
     }
 
     /**
@@ -275,6 +275,16 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
     }
 
     /**
+     * Resume consuming when timeout is over.
+     *
+     * @return bool
+     */
+    public function shouldResume(): bool
+    {
+        return $this->resume;
+    }
+
+    /**
      * Send message using AMQP producer.
      *
      * @param Producer            $producer
@@ -286,15 +296,5 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
     protected function sendMessage(Producer $producer, $destination, Message $message): void
     {
         $producer->send($destination, $message);
-    }
-
-    /**
-     * Resume consuming when timeout is over.
-     *
-     * @return bool
-     */
-    public function shouldResume(): bool
-    {
-        return $this->resume;
     }
 }

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -41,18 +41,25 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
     protected $delayed_exchange;
 
     /**
+     * @var bool
+     */
+    protected $resume;
+
+    /**
      * Create a new Queue instance.
      *
      * @param Container      $container
      * @param Context        $connection
      * @param AmqpQueue      $queue
      * @param int            $timeout
+     * @param bool           $resume
      * @param AmqpTopic|null $delayed_exchange
      */
     public function __construct(Container $container,
                                 Context $connection,
                                 AmqpQueue $queue,
                                 int $timeout = 0,
+                                bool $resume = false,
                                 ?AmqpTopic $delayed_exchange = null)
     {
         $this->container        = $container;
@@ -60,6 +67,7 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
         $this->queue            = $queue;
         $this->timeout          = \max(0, $timeout);
         $this->delayed_exchange = $delayed_exchange;
+        $this->resume = $resume;
     }
 
     /**
@@ -278,5 +286,15 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
     protected function sendMessage(Producer $producer, $destination, Message $message): void
     {
         $producer->send($destination, $message);
+    }
+
+    /**
+     * Resume consuming when timeout is over.
+     *
+     * @return bool
+     */
+    public function shouldResume(): bool
+    {
+        return $this->resume;
     }
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -96,7 +96,7 @@ class Worker extends \Illuminate\Queue\Worker
             $this->closeRabbitConnection($rabbit_connection);
 
             $this->stop();
-            // @codeCoverageIgnoreStart
+        // @codeCoverageIgnoreStart
         } else {
             // Backward compatibility is our everything =)
             parent::daemon($connectionName, $queue_names, $options);

--- a/tests/Commands/WorkCommandTest.php
+++ b/tests/Commands/WorkCommandTest.php
@@ -7,6 +7,7 @@ namespace AvtoDev\AmqpRabbitLaravelQueue\Tests\Commands;
 use AvtoDev\AmqpRabbitLaravelQueue\Worker;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\AbstractTestCase;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @covers \AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand<extended>
@@ -29,5 +30,22 @@ class WorkCommandTest extends AbstractTestCase
 
             $this->assertInstanceOf(Worker::class, $worker);
         }
+    }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testCustomizedCommandOptions(): void
+    {
+        /** @var WorkCommand $command */
+        $command = $this->app->make('command.queue.work');
+
+        /** @var InputOption[] $options */
+        $options = $command->getDefinition()->getOptions();
+
+        $this->assertRegExp('~not used~i', $options['sleep']->getDescription());
+        $this->assertEquals(-1, $options['timeout']->getDefault());
     }
 }

--- a/tests/Commands/WorkCommandTest.php
+++ b/tests/Commands/WorkCommandTest.php
@@ -5,9 +5,9 @@ declare(strict_types = 1);
 namespace AvtoDev\AmqpRabbitLaravelQueue\Tests\Commands;
 
 use AvtoDev\AmqpRabbitLaravelQueue\Worker;
+use Symfony\Component\Console\Input\InputOption;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\AbstractTestCase;
-use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @covers \AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand<extended>

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -77,6 +77,34 @@ class ConnectorTest extends AbstractTestCase
      *
      * @return void
      */
+    public function testCommentWithResumeParameter(): void
+    {
+        /* @var Queue $queue */
+        $this->assertInstanceOf(Queue::class, $queue = $this->connector->connect([
+            'connection' => $this->temp_rabbit_connection_name,
+            'queue_id'   => $this->temp_rabbit_queue_id,
+            'timeout'    => 100,
+            'resume'     => $resume = true,
+        ]));
+
+        $this->assertSame($resume, $queue->shouldResume());
+
+        /* @var Queue $queue */
+        $this->assertInstanceOf(Queue::class, $queue = $this->connector->connect([
+            'connection' => $this->temp_rabbit_connection_name,
+            'queue_id'   => $this->temp_rabbit_queue_id,
+            'timeout'    => 100,
+            'resume'     => $resume = false,
+        ]));
+
+        $this->assertSame($resume, $queue->shouldResume());
+    }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
     public function testExceptionThrownWithoutConnectionPassing(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Feature/AbstractFeatureTest.php
+++ b/tests/Feature/AbstractFeatureTest.php
@@ -92,12 +92,14 @@ abstract class AbstractFeatureTest extends AbstractTestCase
      * @param string     $command
      * @param array      $arguments
      * @param float|null $process_timeout
+     * @param array|null $env
      *
      * @return array
      */
     protected function startArtisan(string $command,
                                     array $arguments = [],
-                                    ?float $process_timeout = null): array
+                                    ?float $process_timeout = null,
+                                    ?array $env = null): array
     {
         $process_timeout = (float) env('ARTISAN_PROCESS_TIMEOUT', $process_timeout ?? 0.65);
 
@@ -110,7 +112,7 @@ abstract class AbstractFeatureTest extends AbstractTestCase
             \realpath(__DIR__ . '/../bin/artisan'),
             $command,
             '--no-ansi',
-        ], $arguments), base_path(), null, null, $process_timeout);
+        ], $arguments), base_path(), $env, null, $process_timeout);
 
         $lineToArray = function (string $line): array {
             $lines = \preg_split("~(\r|\n)~", $line);

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -250,6 +250,7 @@ class QueueTest extends AbstractTestCase
             $this->temp_rabbit_connection,
             $this->temp_rabbit_queue,
             0,
+            false,
             $this->temp_rabbit_exchange,
         ])
             ->shouldAllowMockingProtectedMethods()
@@ -340,6 +341,7 @@ class QueueTest extends AbstractTestCase
             $this->app,
             $this->temp_rabbit_connection,
             $this->temp_rabbit_queue,
+            false,
             0,
             $this->temp_rabbit_exchange,
         ])
@@ -410,6 +412,7 @@ class QueueTest extends AbstractTestCase
             $this->app,
             $this->temp_rabbit_connection,
             $this->temp_rabbit_queue,
+            false,
             0,
             $this->temp_rabbit_exchange,
         ])
@@ -480,6 +483,7 @@ class QueueTest extends AbstractTestCase
             $this->app,
             $this->temp_rabbit_connection,
             $this->temp_rabbit_queue,
+            false,
             0,
             $this->temp_rabbit_exchange,
         ])

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -123,7 +123,7 @@ class WorkerTest extends AbstractTestCase
         \usleep(1500);
         $this->assertSame(1, $queue->size());
 
-        $this->worker->daemon($this->queue_connection_name, 'default', new WorkerOptions);
+        $this->worker->daemon($this->queue_connection_name, 'default', new WorkerOptions(0, 32, -1));
 
         $this->assertSame(0, $queue->size());
     }
@@ -167,7 +167,7 @@ class WorkerTest extends AbstractTestCase
         \usleep(8500);
         $this->assertSame(1, $queue->size());
 
-        $this->worker->daemon($this->queue_connection_name, 'default', new WorkerOptions(0, 32, 60, 3, 2));
+        $this->worker->daemon($this->queue_connection_name, 'default', new WorkerOptions(0, 32, -1, 3, 2));
         \usleep(8500);
         $this->assertSame(0, $queue->size()); // There is no 'jobs.failer', so, failed job should be 'deleted
     }

--- a/tests/bin/artisan
+++ b/tests/bin/artisan
@@ -19,6 +19,11 @@ require __DIR__.'/../../vendor/autoload.php';
 
 $app = require_once __DIR__ . '/../bootstrap/app.php';
 
+// Load customized configuration
+foreach (glob(__DIR__ . '/../config/*.php') as $file) {
+    config()->set(basename($file, '.php'), require $file);
+}
+
 /*
 |--------------------------------------------------------------------------
 | Run The Artisan Application

--- a/tests/config/queue.php
+++ b/tests/config/queue.php
@@ -11,7 +11,8 @@ return [
             'connection'          => 'rabbit-default',
             'queue_id'            => 'jobs',
             'delayed_exchange_id' => 'delayed-jobs',
-            'timeout'             => 0,
+            'timeout'             => (int) env('QUEUE_TIMEOUT', 0),
+            'resume'              => (bool) env('QUEUE_RESUME', false),
         ],
     ],
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

### Added

- Queue driver `resume` option _(can be used for periodic connection reloading)_

### Changed

- `Queue` class constructor signature
- Option `sleep` for `queue:work` command marked as unused
- Option `timeout` for `queue:work` now `-1` by default. It means next - by default used timeout value from configuration file, but this value can be overridden by passing `--timeout` option with `0..+n` value

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/amqp-rabbit-laravel-queue/blob/master/CHANGELOG.md) file

> About your changes in `CHANGELOG.md`:
>
> * Add new version header like `## v1.x.x`, if it does not exists
> * Add description under `added`/`changed`/`fixed` sections
> * Add reference to closed issues `[#000]`
> * Add link to issue in the end of document
