### PR TITLE
Automatic Job state binding into IoC container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,24 +96,25 @@ after_success:
 matrix:
   include:
     - php: 7.1.3
-    - php: 7.1.3
       env: setup=lowest
-    - php: 7.1.3
-      env: setup=stable coverage=true
-
     - php: 7.2
+      env: laravel=5.7
+    - php: 7.1.3
+      env: coverage=true
+
     - php: 7.2
       env: setup=lowest
     - php: 7.2
       env: laravel=5.7
     - php: 7.2
-      env: setup=stable coverage=true
+      env: coverage=true
 
-    - php: 7.3
     - php: 7.3
       env: setup=lowest
     - php: 7.3
-      env: setup=stable coverage=true
+      env: laravel=5.7
+    - php: 7.3
+      env: coverage=true
 
     - php: nightly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.2.0
+
+### Added
+
+- Automatic Job state (`JobStateInterface`) binding into IoC container
+
 ## v2.1.0
 
 ### Added

--- a/src/JobState.php
+++ b/src/JobState.php
@@ -34,7 +34,7 @@ class JobState extends Collection implements JobStateInterface
     public function put($key, $value)
     {
         if (\is_resource($value) || $value instanceof Closure) {
-            throw new InvalidArgumentException;
+            throw new InvalidArgumentException('Wrong value passed');
         }
 
         parent::put($key, $value);

--- a/src/Listeners/BindJobStateListener.php
+++ b/src/Listeners/BindJobStateListener.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\AmqpRabbitLaravelQueue\Listeners;
+
+use AvtoDev\AmqpRabbitLaravelQueue\Job;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Contracts\Container\Container;
+use AvtoDev\AmqpRabbitLaravelQueue\JobStateInterface;
+
+class BindJobStateListener
+{
+    /**
+     * @var Container
+     */
+    protected $container;
+
+    /**
+     * Create a new BindJobStateListener instance.
+     *
+     * @param Container $container
+     */
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Handle event.
+     *
+     * @param JobProcessing $event
+     */
+    public function handle(JobProcessing $event): void
+    {
+        if ($event->job instanceof Job) {
+            $this->container->instance(JobStateInterface::class, $event->job->state());
+        }
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,6 +6,7 @@ namespace AvtoDev\AmqpRabbitLaravelQueue;
 
 use Illuminate\Queue\QueueManager;
 use Illuminate\Container\Container;
+use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Queue\Worker as IlluminateWorker;
 use AvtoDev\AmqpRabbitManager\QueuesFactoryInterface;
@@ -150,5 +151,6 @@ class ServiceProvider extends IlluminateServiceProvider
     {
         $events->listen(ExchangeCreated::class, Listeners\CreateExchangeBind::class);
         $events->listen(ExchangeDeleting::class, Listeners\RemoveExchangeBind::class);
+        $events->listen(JobProcessing::class, Listeners\BindJobStateListener::class);
     }
 }

--- a/tests/JobStateTest.php
+++ b/tests/JobStateTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Tests\Unit\AvtoDev\AmqpRabbitLaravelQueue\Tests;
 
+use Serializable;
+use InvalidArgumentException;
 use AvtoDev\AmqpRabbitLaravelQueue\JobState;
 use AvtoDev\AmqpRabbitLaravelQueue\JobStateInterface;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\AbstractTestCase;
@@ -16,7 +18,7 @@ class JobStateTest extends AbstractTestCase
     /**
      * @var JobState
      */
-    protected $job_state_class;
+    protected $instance;
 
     /**
      * {@inheritdoc}
@@ -25,8 +27,18 @@ class JobStateTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->job_state_class = $this->app->make(JobState::class);
-        $this->assertInstanceOf(JobStateInterface::class, $this->job_state_class);
+        $this->instance = new JobState;
+    }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testInstanceOf(): void
+    {
+        $this->assertInstanceOf(JobStateInterface::class, $this->instance);
+        $this->assertInstanceOf(Serializable::class, $this->instance);
     }
 
     /**
@@ -37,7 +49,7 @@ class JobStateTest extends AbstractTestCase
     public function testExistedMethods(): void
     {
         foreach (['serialize', 'unserialize', 'put', 'all', 'has', 'get', 'put', 'isEmpty', 'forget'] as $method) {
-            $this->assertTrue(\method_exists($this->job_state_class, $method));
+            $this->assertTrue(\method_exists($this->instance, $method));
         }
     }
 
@@ -48,9 +60,9 @@ class JobStateTest extends AbstractTestCase
      */
     public function testSerializeMethod(): void
     {
-        $this->job_state_class->put('some_items', $items = ['foo', 'bar', 23]);
+        $this->instance->put('some_items', $items = ['foo', 'bar', 23]);
 
-        $this->assertSame(\serialize(['some_items' => $items]), $this->job_state_class->serialize());
+        $this->assertSame(\serialize(['some_items' => $items]), $this->instance->serialize());
     }
 
     /**
@@ -61,24 +73,9 @@ class JobStateTest extends AbstractTestCase
     public function testUnserializeMethod(): void
     {
         $data = \serialize($items = ['some_items' => ['foo', 'bar', 23]]);
-        $this->job_state_class->unserialize($data);
+        $this->instance->unserialize($data);
 
-        $this->assertSame($items, $this->job_state_class->all());
-    }
-
-    /**
-     * @small
-     *
-     * @return void
-     */
-    public function testPutMethod(): void
-    {
-        foreach (['item_name', 'foo', 'bar', 23] as $item) {
-            $return_value = $this->job_state_class->put($item, [$item]);
-
-            $this->assertNull($return_value);
-            $this->assertSame([$item], $this->job_state_class->get($item));
-        }
+        $this->assertSame($items, $this->instance->all());
     }
 
     /**
@@ -91,5 +88,44 @@ class JobStateTest extends AbstractTestCase
         $data = [123, 'foo' => 'bar', false, null, \M_PI];
 
         $this->assertSame($data, \unserialize(\serialize(new JobState($data)))->all());
+    }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testPutMethod(): void
+    {
+        foreach (['item_name', 'foo', 'bar', 23] as $item) {
+            $this->assertNull($this->instance->put($item, [$item]));
+            $this->assertSame([$item], $this->instance->get($item));
+        }
+    }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testPutThrowsAnExceptionWhenPassedCallable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('~Wrong value passed~i');
+
+        $this->instance->put('foo', function (): void {});
+    }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testPutThrowsAnExceptionWhenPassedResource(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('~Wrong value passed~i');
+
+        $this->instance->put('foo', \tmpfile());
     }
 }

--- a/tests/JobStateTest.php
+++ b/tests/JobStateTest.php
@@ -113,7 +113,8 @@ class JobStateTest extends AbstractTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('~Wrong value passed~i');
 
-        $this->instance->put('foo', function (): void {});
+        $this->instance->put('foo', function (): void {
+        });
     }
 
     /**

--- a/tests/Listeners/CreateExchangeBindTest.php
+++ b/tests/Listeners/CreateExchangeBindTest.php
@@ -11,6 +11,8 @@ use AvtoDev\AmqpRabbitLaravelQueue\Listeners\CreateExchangeBind;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTrait;
 
 /**
+ * @group listeners
+ *
  * @covers \AvtoDev\AmqpRabbitLaravelQueue\Listeners\CreateExchangeBind<extended>
  */
 class CreateExchangeBindTest extends AbstractExchangeListenerTestCase

--- a/tests/Listeners/RemoveExchangeBindTest.php
+++ b/tests/Listeners/RemoveExchangeBindTest.php
@@ -11,6 +11,8 @@ use AvtoDev\AmqpRabbitLaravelQueue\Listeners\RemoveExchangeBind;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTrait;
 
 /**
+ * @group listeners
+ *
  * @covers \AvtoDev\AmqpRabbitLaravelQueue\Listeners\RemoveExchangeBind<extended>
  */
 class RemoveExchangeBindTest extends AbstractExchangeListenerTestCase

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace AvtoDev\AmqpRabbitLaravelQueue\Tests;
 
+use AvtoDev\AmqpRabbitLaravelQueue\Listeners\BindJobStateListener;
+use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\QueueManager;
 use AvtoDev\AmqpRabbitLaravelQueue\Worker;
 use AvtoDev\AmqpRabbitLaravelQueue\Connector;
@@ -56,6 +58,7 @@ class ServiceProviderTest extends AbstractTestCase
     {
         $this->assertContains(CreateExchangeBind::class, $this->getEventListenersClasses(ExchangeCreated::class));
         $this->assertContains(RemoveExchangeBind::class, $this->getEventListenersClasses(ExchangeDeleting::class));
+        $this->assertContains(BindJobStateListener::class, $this->getEventListenersClasses(JobProcessing::class));
     }
 
     /**

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -4,10 +4,9 @@ declare(strict_types = 1);
 
 namespace AvtoDev\AmqpRabbitLaravelQueue\Tests;
 
-use AvtoDev\AmqpRabbitLaravelQueue\Listeners\BindJobStateListener;
-use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\QueueManager;
 use AvtoDev\AmqpRabbitLaravelQueue\Worker;
+use Illuminate\Queue\Events\JobProcessing;
 use AvtoDev\AmqpRabbitLaravelQueue\Connector;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand;
@@ -16,6 +15,7 @@ use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreated;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleting;
 use AvtoDev\AmqpRabbitLaravelQueue\Listeners\CreateExchangeBind;
 use AvtoDev\AmqpRabbitLaravelQueue\Listeners\RemoveExchangeBind;
+use AvtoDev\AmqpRabbitLaravelQueue\Listeners\BindJobStateListener;
 use AvtoDev\AmqpRabbitLaravelQueue\Failed\RabbitQueueFailedJobProvider;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTrait;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

### Added

- Automatic Job state (`JobStateInterface`) binding into IoC container

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/amqp-rabbit-laravel-queue/blob/master/CHANGELOG.md) file

> About your changes in `CHANGELOG.md`:
>
> * Add new version header like `## v1.x.x`, if it does not exists
> * Add description under `added`/`changed`/`fixed` sections
> * Add reference to closed issues `[#000]`
> * Add link to issue in the end of document
