### PR TITLE
Disable consumer unsubscribing in worker class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ branches:
 
 before_install:
   # Install RabbitMQ server
+  - find / -type f -name jdk_switcher.sh 2> /dev/null
   - sudo mv /opt/jdk_switcher/jdk_switcher.sh /tmp
     && sudo apt-get install rabbitmq-server=${RABBITMQ_VER}-1
     && sudo mv /tmp/jdk_switcher.sh /opt/jdk_switcher/

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,7 @@ branches:
 
 before_install:
   # Install RabbitMQ server
-  - find / -type f -name jdk_switcher.sh 2> /dev/null
-  - sudo mv /opt/jdk_switcher/jdk_switcher.sh /tmp
-    && sudo apt-get install rabbitmq-server=${RABBITMQ_VER}-1
-    && sudo mv /tmp/jdk_switcher.sh /opt/jdk_switcher/
+  - sudo apt-get install rabbitmq-server=${RABBITMQ_VER}-1
   # Install rabbit-c
   - if [ ! -d "$HOME/rabbitmq-c/${RABBIT_C_VER}" ]; then
     travis_retry git clone --branch v${RABBIT_C_VER} https://github.com/alanxz/rabbitmq-c.git $HOME/rabbitmq-c/${RABBIT_C_VER};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.2.1
+
+### Fixed
+
+- `$subscriber->unsubscribe($consumer);` disabled in `Worker` class (possible fix exception `AMQPEnvelopeException: Orphaned envelope`)
+
 ## v2.2.0
 
 ### Added

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -88,7 +88,7 @@ class Worker extends \Illuminate\Queue\Worker
 
                 $subscriber->consume($this->getTimeoutForWork($options, $queue)); // Start `subscribe` method loop
 
-//                $subscriber->unsubscribe($consumer);
+                //$subscriber->unsubscribe($consumer); // Disabled since v2.2.1
             } while (
                 $queue->shouldResume() === true && $this->needToStop($options, $last_restart) === false
             );

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -88,7 +88,7 @@ class Worker extends \Illuminate\Queue\Worker
 
                 $subscriber->consume($this->getTimeoutForWork($options, $queue)); // Start `subscribe` method loop
 
-                $subscriber->unsubscribe($consumer);
+//                $subscriber->unsubscribe($consumer);
             } while (
                 $queue->shouldResume() === true && $this->needToStop($options, $last_restart) === false
             );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

### Fixed

- `$subscriber->unsubscribe($consumer);` disabled in `Worker` class (possible fix exception `AMQPEnvelopeException: Orphaned envelope`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/amqp-rabbit-laravel-queue/blob/master/CHANGELOG.md) file