### PR TITLE
Laravel 8.x is supported now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,15 +33,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '7.3'
             setup: basic
             coverage: no
-            laravel: '~5.7.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.8.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^6.0'
+            laravel: '^7.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.5.0
+
+### Changed
+
+- Laravel `8.x` is supported now
+- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)
+
+### Removed
+
+- Code for previous `illuminate/queue` (older that `~6.0`) versions support
+
 ## v2.4.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.23-alpine
+FROM php:7.3.5-alpine
 
 ENV \
     # <https://github.com/alanxz/rabbitmq-c>
@@ -8,7 +8,7 @@ ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
@@ -27,7 +27,7 @@ RUN set -x \
     # workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.1 1>/dev/null \
+    && pecl install xdebug-2.9.6 1>/dev/null \
     # this c-library is required for 'php-amqp'
     && ( git clone --branch v${RABBITMQ_VERSION} https://github.com/alanxz/rabbitmq-c.git /tmp/rabbitmq \
         && cd /tmp/rabbitmq \

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,8 @@
 # Makefile readme (ru): <http://linux.yaroslavl.ru/docs/prog/gnu_make_3-79_russian_manual.html>
 # Makefile readme (en): <https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents>
 
-dc_bin := $(shell command -v docker-compose 2> /dev/null)
-
 SHELL = /bin/sh
-RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
+RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)"
 
 .PHONY : help install latest lowest test test-cover shell
 .DEFAULT_GOAL : help
@@ -16,32 +14,31 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	$(dc_bin) build
+	docker-compose build
 
 install: clean ## Install stable php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
 
 latest: clean ## Install latest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
 
 lowest: clean ## Install lowest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
 
 test: up ## Execute php tests and linters
-	$(dc_bin) run $(RUN_APP_ARGS) sh -c "sleep 5 && composer test"
+	docker-compose run $(RUN_APP_ARGS) app sh -c "sleep 5 && composer test"
 
 test-cover: up ## Execute php tests with coverage
-	$(dc_bin) run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer test-cover"'
+	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer test-cover"'
 
 up: ## Start services
-	$(dc_bin) up -d
+	docker-compose up -d
 
 down: ## Stop services
-	$(dc_bin) down
+	docker-compose down
 
 shell: ## Start shell into container with php
-	$(dc_bin) run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" \
-    $(RUN_APP_ARGS) sh
+	docker-compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,11 @@
         "illuminate/queue": "~6.0 || ~7.0 || ~8.0",
         "illuminate/container": "~6.0 || ~7.0 || ~8.0",
         "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
-        "symfony/console": "^4.4 || ~5.0",
         "avto-dev/amqp-rabbit-manager": "^2.0"
     },
     "require-dev": {
         "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
         "mockery/mockery": "^1.3",
-        "symfony/process": "^4.2",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^8.5.4 || ^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,13 @@
         "illuminate/queue": "~6.0 || ~7.0 || ~8.0",
         "illuminate/container": "~6.0 || ~7.0 || ~8.0",
         "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
+        "symfony/console": "^4.4 || ~5.0",
         "avto-dev/amqp-rabbit-manager": "^2.0"
     },
     "require-dev": {
         "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
         "mockery/mockery": "^1.3",
+        "symfony/process": "^4.2 || ~5.0",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^8.5.4 || ^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,19 @@
         "php": "^7.2",
         "ext-amqp": "*",
         "ext-json": "*",
-        "illuminate/support": "^5.6 || ~6.0 || ~7.0",
-        "illuminate/queue": "^5.6 || ~6.0 || ~7.0",
-        "illuminate/container": "^5.6 || ~6.0 || ~7.0",
-        "illuminate/contracts": "^5.6 || ~6.0 || ~7.0",
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/queue": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/container": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
         "symfony/console": "^4.4 || ~5.0",
         "avto-dev/amqp-rabbit-manager": "^2.0"
     },
     "require-dev": {
-        "laravel/laravel": "^5.6 || ~6.0 || ~7.0",
+        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
         "mockery/mockery": "^1.3",
         "symfony/process": "^4.2",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "~7.5"
+        "phpunit/phpunit": "^8.5.4 || ^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - /etc/group:/etc/group:ro
       - .:/src:cached
       - composer-data:/tmp/composer:cached
+    environment:
+      PS1: '\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]'
     depends_on:
       - rabbitmq
     networks:

--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -33,17 +33,7 @@ class WorkCommand extends \Illuminate\Queue\Console\WorkCommand
             '~(--sleep.*)}~', '$1 <options=bold>(not used)</> }', $this->signature
         );
 
-        // Constructor signature in parent class changed since 6.0:
-        // For ~5.5 one argument:
-        // - https://github.com/laravel/framework/blob/v5.5.0/src/Illuminate/Queue/Console/WorkCommand.php#L53
-        // - https://github.com/laravel/framework/blob/v5.6.0/src/Illuminate/Queue/Console/WorkCommand.php#L53
-        // - https://github.com/laravel/framework/blob/v5.7.0/src/Illuminate/Queue/Console/WorkCommand.php#L53
-        // - https://github.com/laravel/framework/blob/v5.8.0/src/Illuminate/Queue/Console/WorkCommand.php#L54
-        // Since ^6.0 - two arguments:
-        // - https://github.com/laravel/framework/blob/v6.0.0/src/Illuminate/Queue/Console/WorkCommand.php#L63
-        // - https://github.com/laravel/framework/blob/v7.0.0/src/Illuminate/Queue/Console/WorkCommand.php#L62
-        //        parent::{'__construct'}(...[$worker, $cache]);
-        parent::__construct(...[$worker, $cache]);
+        parent::__construct($worker, $cache);
     }
 
     /**

--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -72,11 +72,11 @@ class WorkCommand extends \Illuminate\Queue\Console\WorkCommand
      * @param string $connection
      * @param string $queue
      *
-     * @return array<mixed>
+     * @return array<mixed>|int|null
      *
      * @codeCoverageIgnore
      */
-    protected function runWorker($connection, $queue): array
+    protected function runWorker($connection, $queue)
     {
         $this->info('Queue worker started. Press "CTRL+C" to exit');
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace AvtoDev\AmqpRabbitLaravelQueue;
 
 use DateTime;
-use RuntimeException;
 use Illuminate\Support\Str;
 use Interop\Amqp\AmqpQueue;
 use Interop\Amqp\AmqpTopic;
@@ -93,7 +92,7 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
      *
      * @param object|string $job
      * @param mixed         $data
-     * @param string        $queue
+     * @param string|null   $queue
      * @param int|null      $priority Message priority
      *
      * @return void
@@ -108,7 +107,7 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
             $options['priority'] = $job->priority();
         }
 
-        $this->pushRaw($this->createPayloadCompatible($job, $queue, $data), $queue, $options);
+        $this->pushRaw($this->createPayload($job, (string) $queue, $data), $queue, $options);
     }
 
     /**
@@ -149,45 +148,6 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
     }
 
     /**
-     * Create a payload string from the given job and data.
-     *
-     * @param string|mixed $job
-     * @param string|mixed $queue
-     * @param mixed        $data
-     *
-     * @throws RuntimeException
-     * @throws \Illuminate\Queue\InvalidPayloadException
-     *
-     * @return string
-     *
-     * @see \Illuminate\Queue\Queue::createPayload()
-     */
-    public function createPayloadCompatible($job, $queue, $data): string
-    {
-        static $parameters_number, $method_name = 'createPayload';
-
-        if (! \is_int($parameters_number)) {
-            $parameters_number = (new \ReflectionMethod(static::class, $method_name))->getNumberOfParameters();
-        }
-
-        if ($parameters_number === 2) {
-            // @link: https://github.com/laravel/framework/blob/v5.5.0/src/Illuminate/Queue/Queue.php#L85
-            // @link: https://github.com/laravel/framework/blob/v5.6.0/src/Illuminate/Queue/Queue.php#L85
-            // @link: https://github.com/laravel/framework/blob/v5.7.0/src/Illuminate/Queue/Queue.php#L78
-            return $this->{$method_name}($job, $data);
-        }
-
-        if ($parameters_number === 3) {
-            // @link: https://github.com/laravel/framework/blob/v5.8.0/src/Illuminate/Queue/Queue.php#L86
-            return $this->{$method_name}($job, $queue, $data);
-        }
-
-        throw new RuntimeException(
-            "Parent method looks like not compatible with current class (uses {$parameters_number} parameters)"
-        );
-    }
-
-    /**
      * Push a new job onto the queue after a delay.
      *
      * @param \DateTimeInterface|\DateInterval|int|float $delay    Delay in seconds
@@ -209,7 +169,7 @@ class Queue extends \Illuminate\Queue\Queue implements QueueContract
             $options['priority'] = $job->priority();
         }
 
-        $this->pushRaw($this->createPayloadCompatible($job, $queue, $data), $queue, $options);
+        $this->pushRaw($this->createPayload($job, (string) $queue, $data), $queue, $options);
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -90,23 +90,14 @@ class ServiceProvider extends IlluminateServiceProvider
     protected function registerQueueWorker(): void
     {
         $this->app->singleton(Worker::class, function (Container $container): Worker {
-            // Constructor signature changed since 6.0:
-            // For ~5.5 three arguments:
-            // - https://github.com/illuminate/queue/blob/5.5/Worker.php#L68
-            // - https://github.com/illuminate/queue/blob/5.6/Worker.php#L68
-            // - https://github.com/illuminate/queue/blob/5.7/Worker.php#L68
-            // - https://github.com/illuminate/queue/blob/5.8/Worker.php#L68
-            // Since ^6.0 - four arguments:
-            // - https://github.com/illuminate/queue/blob/6.x/Worker.php#L82
-            // - https://github.com/illuminate/queue/blob/7.x/Worker.php#L80
-            return new Worker(...[
+            return new Worker(
                 $container->make('queue'),
                 $container->make('events'),
                 $container->make(ExceptionHandler::class),
                 function (): bool { // Required since illuminate/queue ^6.0
                     return $this->app->isDownForMaintenance();
-                },
-            ]);
+                }
+            );
         });
     }
 

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -9,7 +9,6 @@ use Illuminate\Queue\WorkerOptions;
 use Interop\Amqp\AmqpMessage as Message;
 use Enqueue\AmqpExt\AmqpContext as Context;
 use Enqueue\AmqpExt\AmqpConsumer as Consumer;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class Worker extends \Illuminate\Queue\Worker
 {
@@ -20,9 +19,9 @@ class Worker extends \Illuminate\Queue\Worker
      * @param string        $queue_names
      * @param WorkerOptions $options
      *
-     * @return void
+     * @return void|int
      */
-    public function daemon($connectionName, $queue_names, WorkerOptions $options): void
+    public function daemon($connectionName, $queue_names, WorkerOptions $options)
     {
         $queue = $this->manager->connection($connectionName);
 
@@ -66,7 +65,7 @@ class Worker extends \Illuminate\Queue\Worker
                         } catch (Throwable $e) {
                             $consumer->reject($message); // @todo: move to the failed jobs queue?
 
-                            $this->exceptions->report($e = new FatalThrowableError($e));
+                            $this->exceptions->report($e);
                             $this->stopWorkerIfLostConnection($e);
                             $this->sleep(3);
 
@@ -101,12 +100,12 @@ class Worker extends \Illuminate\Queue\Worker
 
             $this->closeRabbitConnection($rabbit_connection);
 
-            $this->stop();
-        // @codeCoverageIgnoreStart
-        } else {
-            // Backward compatibility is our everything =)
-            parent::daemon($connectionName, $queue_names, $options);
+            return $this->stop();
         }
+
+        // Backward compatibility is our everything =)
+        // @codeCoverageIgnoreStart
+        return parent::daemon($connectionName, $queue_names, $options);
         // @codeCoverageIgnoreEnd
     }
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -7,7 +7,6 @@ use ReflectionFunction;
 use ReflectionException;
 use PHPUnit\Framework\Exception;
 use Illuminate\Foundation\Application;
-use PHPUnit\Framework\InvalidArgumentException;
 use AvtoDev\AmqpRabbitManager\QueuesFactoryInterface;
 use Illuminate\Config\Repository as ConfigRepository;
 use AvtoDev\AmqpRabbitManager\ConnectionsFactoryInterface;
@@ -124,6 +123,8 @@ abstract class AbstractTestCase extends BaseTestCase
 
     /**
      * @deprecated
+     *
+     * @param mixed $object
      */
     protected function getObjectAttributeDeprecated($object, string $attributeName)
     {
@@ -133,7 +134,7 @@ abstract class AbstractTestCase extends BaseTestCase
             try {
                 $attribute = $reflector->getProperty($attributeName);
 
-                if (!$attribute || $attribute->isPublic()) {
+                if (! $attribute || $attribute->isPublic()) {
                     return $object->$attributeName;
                 }
 

--- a/tests/Commands/JobMakeCommandTest.php
+++ b/tests/Commands/JobMakeCommandTest.php
@@ -56,12 +56,12 @@ class JobMakeCommandTest extends AbstractTestCase
 
         require $file_path;
 
-        $this->assertInternalType('object', new \App\Jobs\Foo);
+        $this->assertIsObject(new \App\Jobs\Foo);
 
         $content = \file_get_contents($file_path);
 
         foreach (['$tries', '$priority', 'strict_types', 'class ' . $name] as $value) {
-            $this->assertContains($value, $content);
+            $this->assertStringContainsString($value, $content);
         }
 
         $this->fs->delete($file_path);
@@ -83,12 +83,12 @@ class JobMakeCommandTest extends AbstractTestCase
 
         require $file_path;
 
-        $this->assertInternalType('object', new \App\Jobs\Bar);
+        $this->assertIsObject(new \App\Jobs\Bar);
 
         $content = \file_get_contents($file_path);
 
         foreach (['$tries', 'strict_types', 'class ' . $name] as $value) {
-            $this->assertContains($value, $content);
+            $this->assertStringContainsString($value, $content);
         }
 
         $this->fs->delete($file_path);

--- a/tests/Commands/WorkCommandTest.php
+++ b/tests/Commands/WorkCommandTest.php
@@ -26,7 +26,7 @@ class WorkCommandTest extends AbstractTestCase
             $command = $this->app->make($abstract);
 
             /** @var \Illuminate\Queue\Worker $worker */
-            $worker = $this->getObjectAttribute($command, 'worker');
+            $worker = $this->getObjectAttributeDeprecated($command, 'worker');
 
             $this->assertInstanceOf(Worker::class, $worker);
         }

--- a/tests/Failed/RabbitQueueFailedJobProviderTest.php
+++ b/tests/Failed/RabbitQueueFailedJobProviderTest.php
@@ -61,7 +61,7 @@ class RabbitQueueFailedJobProviderTest extends AbstractTestCase
         $message = $this->getLastMessage();
 
         $this->assertSame($connection_name, $message->getProperty('job-connection-name'));
-        $this->assertInternalType('numeric', $message->getProperty('job-failed-at'));
+        $this->assertIsNumeric($message->getProperty('job-failed-at'));
         $this->assertSame($queue_name, $message->getProperty('job-queue-name'));
         $this->assertSame((string) $exception, $message->getProperty('job-exception'));
         $this->assertSame($message_body, $message->getBody());
@@ -78,10 +78,10 @@ class RabbitQueueFailedJobProviderTest extends AbstractTestCase
      */
     public function testGenerateMessageId(): void
     {
-        $this->assertInternalType('numeric', $this->provider::generateMessageId('foo'));
-        $this->assertInternalType('numeric', $this->provider::generateMessageId(['foo']));
-        $this->assertInternalType('numeric', $this->provider::generateMessageId(['foo', false]));
-        $this->assertInternalType('numeric', $this->provider::generateMessageId(['foo', false], 123));
+        $this->assertIsNumeric($this->provider::generateMessageId('foo'));
+        $this->assertIsNumeric($this->provider::generateMessageId(['foo']));
+        $this->assertIsNumeric($this->provider::generateMessageId(['foo', false]));
+        $this->assertIsNumeric($this->provider::generateMessageId(['foo', false], 123));
     }
 
     /**

--- a/tests/Feature/QueueWorkerTest.php
+++ b/tests/Feature/QueueWorkerTest.php
@@ -247,7 +247,7 @@ class QueueWorkerTest extends AbstractFeatureTest
 
         $when = Sharer::get(SimpleQueueJob::class . '-when');
 
-        $this->assertEquals($this->now + $delay, $when, 'Jobs processed with wrong delay', 1);
+        $this->assertEqualsWithDelta($this->now + $delay, $when, 1, 'Jobs processed with wrong delay');
     }
 
     /**
@@ -269,7 +269,7 @@ class QueueWorkerTest extends AbstractFeatureTest
 
         $when = Sharer::get(QueueJobWithDelay::class . '-when');
 
-        $this->assertEquals($this->now + $job->delay, $when, 'Jobs processed with wrong delay', 1);
+        $this->assertEqualsWithDelta($this->now + $job->delay, $when, 1, 'Jobs processed with wrong delay');
     }
 
     /**
@@ -294,7 +294,7 @@ class QueueWorkerTest extends AbstractFeatureTest
 
         $when = Sharer::get(SimpleQueueJob::class . '-when');
 
-        $this->assertEquals($this->now, $when, 'Jobs processed with wrong delay', 1);
+        $this->assertEqualsWithDelta($this->now, $when, 1, 'Jobs processed with wrong delay');
     }
 
     /**
@@ -391,7 +391,7 @@ class QueueWorkerTest extends AbstractFeatureTest
 
         $when = Sharer::get(QueueJobWithSavedStateDelay::class . '-when');
 
-        $this->assertEquals((new \DateTime)->getTimestamp(), $when + $delay, 'Jobs processed with wrong delay', 1);
+        $this->assertEqualsWithDelta((new \DateTime)->getTimestamp(), $when + $delay, 1, 'Jobs processed with wrong delay');
     }
 
     /**

--- a/tests/JobStateTest.php
+++ b/tests/JobStateTest.php
@@ -110,7 +110,7 @@ class JobStateTest extends AbstractTestCase
     public function testPutThrowsAnExceptionWhenPassedCallable(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('~Wrong value passed~i');
+        $this->expectExceptionMessageMatches('~Wrong value passed~i');
 
         $this->instance->put('foo', function (): void {
         });
@@ -124,7 +124,7 @@ class JobStateTest extends AbstractTestCase
     public function testPutThrowsAnExceptionWhenPassedResource(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('~Wrong value passed~i');
+        $this->expectExceptionMessageMatches('~Wrong value passed~i');
 
         $this->instance->put('foo', \tmpfile());
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -50,7 +50,7 @@ class ServiceProviderTest extends AbstractTestCase
     {
         $this->assertArrayHasKey(
             Connector::NAME,
-            $this->getObjectAttribute($this->app->make(QueueManager::class), 'connectors')
+            $this->getObjectAttributeDeprecated($this->app->make(QueueManager::class), 'connectors')
         );
     }
 
@@ -102,7 +102,7 @@ class ServiceProviderTest extends AbstractTestCase
         /** @var QueueManager $queue */
         $queue = $this->app->make(QueueManager::class);
 
-        $connector = $this->getObjectAttribute($queue, 'connectors')[Connector::NAME];
+        $connector = $this->getObjectAttributeDeprecated($queue, 'connectors')[Connector::NAME];
 
         $this->assertInstanceOf(Connector::class, $connector());
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -89,7 +89,7 @@ class ServiceProviderTest extends AbstractTestCase
         $this->config()->offsetUnset('queue.failed.connection');
         $this->config()->offsetUnset('queue.failed.queue_id');
 
-        $this->assertInstanceOf(DatabaseFailedJobProvider::class, $this->app->make('queue.failer'));
+        $this->assertNotInstanceOf(RabbitQueueFailedJobProvider::class, $this->app->make('queue.failer'));
     }
 
     /**

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -8,7 +8,6 @@ use Illuminate\Queue\QueueManager;
 use AvtoDev\AmqpRabbitLaravelQueue\Worker;
 use Illuminate\Queue\Events\JobProcessing;
 use AvtoDev\AmqpRabbitLaravelQueue\Connector;
-use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\JobMakeCommand;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreated;


### PR DESCRIPTION
## Description

### Changed

- Laravel `8.x` is supported now
- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)

### Removed

- Code for previous `illuminate/queue` (older that `~6.0`) versions support

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
