### PR TITLE
Add laravel 8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,20 +28,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.2', '7.3', '7.4']
-        include:
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.7.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.8.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^6.0'
+        php: ['7.3', '7.4']
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -51,7 +38,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, amqp
-          tools: composer:v1 # TODO update composer up to v2
+          tools: composer:v2
 
       - name: Start RabbitMQ server
         run: |
@@ -73,20 +60,17 @@ jobs: # Docs: <https://git.io/JvxXE>
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install Composer 'hirak/prestissimo' package
-        run: composer global require hirak/prestissimo --update-no-dev --no-progress --ansi
-
       - name: Install lowest Composer dependencies
         if: matrix.setup == 'lowest'
-        run: composer update --prefer-dist --no-suggest --prefer-lowest --ansi
+        run: composer update --prefer-dist --prefer-lowest --ansi
 
       - name: Install basic Composer dependencies
         if: matrix.setup == 'basic'
-        run: composer update --prefer-dist --no-suggest --ansi
+        run: composer update --prefer-dist --ansi
 
       - name: Install specific laravel version
         if: matrix.laravel != 'default'
-        run: composer require --dev --update-with-all-dependencies --prefer-dist --no-suggest --ansi laravel/laravel "${{ matrix.laravel }}"
+        run: composer require --dev --update-with-all-dependencies --prefer-dist --ansi laravel/laravel "${{ matrix.laravel }}"
 
       - name: Show most important packages versions
         run: composer info | grep -e laravel -e phpunit -e phpstan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## UNRELEASED
 
+### Added
+
+- Ability to define a custom queue consumer tag prefix
+
 ### Changed
 
 - Minimal required PHP version now is `7.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Minimal required PHP version now is `7.3`
+- Minimal `symfony/*` version now is `5.1`
+- Minimal `illuminate/*` package versions now is `8.0`
+- Minimal `laravel/laravel` package versions now is `8.0`
+- Minimal `phpunit/phpunit` package versions now is `9.3`
+- Minimal `avto-dev/amqp-rabbit-manager` package versions now is `2.3`
+- Version of `php` in docker container updated up to `7.3`
+- Version of `composer` in docker container updated up to `2.0.12`
+
 ## v2.4.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV \
     RABBITMQ_VERSION="0.10.0" \
     # ext-amqp <https://github.com/pdezwart/php-amqp>
     PHP_AMQP_VERSION="1.10.2" \
-    COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
 COPY --from=composer:2.0.12 /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.23-alpine
+FROM php:7.3-alpine
 
 ENV \
     # <https://github.com/alanxz/rabbitmq-c>
@@ -8,7 +8,7 @@ ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.0.12 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
@@ -46,7 +46,6 @@ RUN set -x \
         && rm -Rf /tmp/php-amqp \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
-    && composer global require 'hirak/prestissimo' --no-interaction --no-suggest --prefer-dist \
     && ln -s /usr/bin/composer /usr/bin/c \
     && chmod -R 777 ${COMPOSER_HOME} \
     && composer --version \

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ build: ## Build docker images, required for current package environment
 	$(dc_bin) build
 
 install: clean ## Install stable php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction --no-suggest
+	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction
 
 latest: clean ## Install latest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --prefer-dist --prefer-stable
 
 lowest: clean ## Install lowest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --prefer-dist --prefer-lowest
 
 test: up ## Execute php tests and linters
 	$(dc_bin) run $(RUN_APP_ARGS) sh -c "sleep 5 && composer test"

--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ Using this package you can store any variables (except resources and callable en
 
 #### Consumer custom tag prefix
 
-The prefix of the consumer queue tag can be specified with an additional argument in the `AvtoDev\AmqpRabbitLaravelQueue\Worker::__construct` method.
+Every consumer has an identifier that is used by client libraries to determine what handler to invoke for a given delivery. Their names vary from protocol to protocol. Consumer tags and subscription IDs are two most commonly used terms.
+
+If you want to add custom prefix to the consumer tag, you can specify it with an additional argument in the `AvtoDev\AmqpRabbitLaravelQueue\Worker::__construct` method.
 
 ### :warning: Warning
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,11 @@ You can dispatch your jobs as usual (`dispatch(new Job)` or `dispatch(new Job)->
 
 #### State storing
 
-Using this package you can store any valiables (except resources and callable entities) between job restarts (just use trait `WithJobStateTrait` in your job class). But you should remember - state is available only inside job `handle` method.
+Using this package you can store any variables (except resources and callable entities) between job restarts (just use trait `WithJobStateTrait` in your job class). But you should remember - state is available only inside job `handle` method.
+
+#### Consumer custom tag prefix
+
+The prefix of the consumer queue tag can be specified with an additional argument in the `AvtoDev\AmqpRabbitLaravelQueue\Worker::__construct` method.
 
 ### :warning: Warning
 

--- a/composer.json
+++ b/composer.json
@@ -17,22 +17,22 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-amqp": "*",
         "ext-json": "*",
-        "illuminate/support": "^5.6 || ~6.0 || ~7.0",
-        "illuminate/queue": "^5.6 || ~6.0 || ~7.0",
-        "illuminate/container": "^5.6 || ~6.0 || ~7.0",
-        "illuminate/contracts": "^5.6 || ~6.0 || ~7.0",
-        "symfony/console": "^4.4 || ~5.0",
-        "avto-dev/amqp-rabbit-manager": "^2.0"
+        "illuminate/support": "^8.0",
+        "illuminate/queue": "^8.0",
+        "illuminate/container": "^8.0",
+        "illuminate/contracts": "^8.0",
+        "symfony/console": "^5.1",
+        "avto-dev/amqp-rabbit-manager": "^2.3"
     },
     "require-dev": {
-        "laravel/laravel": "^5.6 || ~6.0 || ~7.0",
+        "laravel/laravel": "^8.0",
         "mockery/mockery": "^1.3",
-        "symfony/process": "^4.2",
+        "symfony/process": "^5.1",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "~7.5"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -10,28 +10,27 @@
          forceCoversAnnotation="true"
          processIsolation="false"
          stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <logging>
-        <!--log type="coverage-html" target="./coverage/html"/-->
-        <log type="coverage-xml" target="./coverage/xml"/>
-        <log type="coverage-clover" target="./coverage/clover.xml"/>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-    </logging>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-        <env name="APP_DEBUG" value="true"/>
-    </php>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="./coverage/clover.xml"/>
+      <text outputFile="php://stdout" showUncoveredFiles="false"/>
+      <xml outputDirectory="./coverage/xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_ENV" value="testing"/>
+    <server name="QUEUE_DRIVER" value="sync"/>
+    <server name="APP_DEBUG" value="true"/>
+  </php>
 </phpunit>

--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -79,14 +79,11 @@ class WorkCommand extends \Illuminate\Queue\Console\WorkCommand
     /**
      * Run the worker instance.
      *
-     * @param string $connection
-     * @param string $queue
-     *
-     * @return array<mixed>
+     * @inheritdoc
      *
      * @codeCoverageIgnore
      */
-    protected function runWorker($connection, $queue): array
+    protected function runWorker($connection, $queue)
     {
         $this->info('Queue worker started. Press "CTRL+C" to exit');
 

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Queue\Factory as QueueManager;
 
 class Worker extends \Illuminate\Queue\Worker
 {
-    /** @var string */
+    /** @var string|null */
     protected $consumer_tag;
 
     /**
@@ -26,7 +26,7 @@ class Worker extends \Illuminate\Queue\Worker
                                 Dispatcher $events,
                                 ExceptionHandler $exceptions,
                                 callable $isDownForMaintenance,
-                                string $consumer_tag = '')
+                                ?string $consumer_tag = null)
     {
         parent::__construct($manager, $events, $exceptions, $isDownForMaintenance);
 
@@ -34,8 +34,6 @@ class Worker extends \Illuminate\Queue\Worker
     }
 
     /**
-     * Listen to the given queue in a loop.
-     *
      * @inheritdoc
      */
     public function daemon($connectionName, $queue, WorkerOptions $options)
@@ -55,7 +53,7 @@ class Worker extends \Illuminate\Queue\Worker
             $consumer   = $rabbit_connection->createConsumer($rabbit_queue);
             $subscriber = $rabbit_connection->createSubscriptionConsumer();
 
-            if ($this->consumer_tag) {
+            if ($this->consumer_tag !== null) {
                 $consumer->setConsumerTag(\uniqid($this->consumer_tag . '-', true));
             }
 

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -14,11 +14,13 @@ use Illuminate\Contracts\Queue\Factory as QueueManager;
 
 class Worker extends \Illuminate\Queue\Worker
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     */
     protected $consumer_tag;
 
     /**
-     * @param string $consumer_tag
+     * @param string|null $consumer_tag
      *
      * {@inheritdoc}
      */

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -4,37 +4,31 @@ declare(strict_types = 1);
 
 namespace AvtoDev\AmqpRabbitLaravelQueue;
 
-use Throwable;
 use Illuminate\Queue\WorkerOptions;
 use Interop\Amqp\AmqpMessage as Message;
 use Enqueue\AmqpExt\AmqpContext as Context;
 use Enqueue\AmqpExt\AmqpConsumer as Consumer;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class Worker extends \Illuminate\Queue\Worker
 {
     /**
      * Listen to the given queue in a loop.
      *
-     * @param string        $connectionName
-     * @param string        $queue_names
-     * @param WorkerOptions $options
-     *
-     * @return void
+     * @inheritdoc
      */
-    public function daemon($connectionName, $queue_names, WorkerOptions $options): void
+    public function daemon($connectionName, $queue, WorkerOptions $options)
     {
-        $queue = $this->manager->connection($connectionName);
+        $queue_connection = $this->manager->connection($connectionName);
 
         // This worker should work with RabbitMQ queue, or not?
-        if ($queue instanceof Queue) {
+        if ($queue_connection instanceof Queue) {
             if ($this->supportsAsyncSignals()) {
                 $this->listenForSignals();
             }
 
             $last_restart      = (int) $this->getTimestampOfLastQueueRestart();
-            $rabbit_connection = $queue->getRabbitConnection();
-            $rabbit_queue      = $queue->getRabbitQueue();
+            $rabbit_connection = $queue_connection->getRabbitConnection();
+            $rabbit_queue      = $queue_connection->getRabbitQueue();
 
             $consumer   = $rabbit_connection->createConsumer($rabbit_queue);
             $subscriber = $rabbit_connection->createSubscriptionConsumer();
@@ -43,16 +37,16 @@ class Worker extends \Illuminate\Queue\Worker
                 $subscriber->subscribe(
                     $consumer,
                     function (Message $message, Consumer $consumer) use (
-                        $queue,
+                        $queue_connection,
                         $connectionName,
-                        $queue_names,
+                        $queue,
                         $options,
                         $last_restart
                     ): bool {
                         // Before reserving any jobs, we will make sure this queue is not paused and
                         // if it is we will just pause this worker for a given amount of time and
                         // make sure we do not need to kill this worker process off completely.
-                        if (! $this->daemonShouldRun($options, $connectionName, $queue_names)) {
+                        if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
                             $consumer->reject($message);
 
                             $this->pauseWorker($options, $last_restart);
@@ -62,11 +56,11 @@ class Worker extends \Illuminate\Queue\Worker
 
                         // Make job instance, based on incoming message
                         try {
-                            $job = $queue->convertMessageToJob($message, $consumer);
-                        } catch (Throwable $e) {
+                            $job = $queue_connection->convertMessageToJob($message, $consumer);
+                        } catch (\Throwable $e) {
                             $consumer->reject($message); // @todo: move to the failed jobs queue?
 
-                            $this->exceptions->report($e = new FatalThrowableError($e));
+                            $this->exceptions->report($e);
                             $this->stopWorkerIfLostConnection($e);
                             $this->sleep(3);
 
@@ -92,20 +86,20 @@ class Worker extends \Illuminate\Queue\Worker
                     }
                 );
 
-                $subscriber->consume($this->getTimeoutForWork($options, $queue)); // Start `subscribe` method loop
+                $subscriber->consume($this->getTimeoutForWork($options, $queue_connection)); // Start `subscribe` method loop
 
                 //$subscriber->unsubscribe($consumer); // Disabled since v2.2.1
             } while (
-                $queue->shouldResume() === true && $this->needToStop($options, $last_restart) === false
+                $queue_connection->shouldResume() === true && $this->needToStop($options, $last_restart) === false
             );
 
             $this->closeRabbitConnection($rabbit_connection);
 
-            $this->stop();
+            return $this->stop();
         // @codeCoverageIgnoreStart
         } else {
             // Backward compatibility is our everything =)
-            parent::daemon($connectionName, $queue_names, $options);
+            return parent::daemon($connectionName, $queue, $options);
         }
         // @codeCoverageIgnoreEnd
     }

--- a/tests/Commands/JobMakeCommandTest.php
+++ b/tests/Commands/JobMakeCommandTest.php
@@ -9,7 +9,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\AbstractTestCase;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\JobMakeCommand;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Commands\JobMakeCommand<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Commands\JobMakeCommand
  */
 class JobMakeCommandTest extends AbstractTestCase
 {
@@ -56,12 +56,12 @@ class JobMakeCommandTest extends AbstractTestCase
 
         require $file_path;
 
-        $this->assertInternalType('object', new \App\Jobs\Foo);
+        $this->assertIsObject(new \App\Jobs\Foo);
 
         $content = \file_get_contents($file_path);
 
         foreach (['$tries', '$priority', 'strict_types', 'class ' . $name] as $value) {
-            $this->assertContains($value, $content);
+            $this->assertStringContainsString($value, $content);
         }
 
         $this->fs->delete($file_path);
@@ -83,12 +83,12 @@ class JobMakeCommandTest extends AbstractTestCase
 
         require $file_path;
 
-        $this->assertInternalType('object', new \App\Jobs\Bar);
+        $this->assertIsObject(new \App\Jobs\Bar);
 
         $content = \file_get_contents($file_path);
 
         foreach (['$tries', 'strict_types', 'class ' . $name] as $value) {
-            $this->assertContains($value, $content);
+            $this->assertStringContainsString($value, $content);
         }
 
         $this->fs->delete($file_path);

--- a/tests/Commands/WorkCommandTest.php
+++ b/tests/Commands/WorkCommandTest.php
@@ -10,7 +10,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\AbstractTestCase;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand
  */
 class WorkCommandTest extends AbstractTestCase
 {
@@ -25,8 +25,12 @@ class WorkCommandTest extends AbstractTestCase
             /** @var \Illuminate\Queue\Console\WorkCommand $command */
             $command = $this->app->make($abstract);
 
+            $reflection = new \ReflectionObject($command);
+            $property = $reflection->getProperty('worker');
+            $property->setAccessible(true);
+
             /** @var \Illuminate\Queue\Worker $worker */
-            $worker = $this->getObjectAttribute($command, 'worker');
+            $worker = $property->getValue($command);
 
             $this->assertInstanceOf(Worker::class, $worker);
         }
@@ -45,7 +49,7 @@ class WorkCommandTest extends AbstractTestCase
         /** @var InputOption[] $options */
         $options = $command->getDefinition()->getOptions();
 
-        $this->assertRegExp('~not used~i', $options['sleep']->getDescription());
+        $this->assertMatchesRegularExpression('~not used~i', $options['sleep']->getDescription());
         $this->assertEquals(-1, $options['timeout']->getDefault());
     }
 }

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -11,7 +11,7 @@ use Illuminate\Queue\Connectors\ConnectorInterface;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTrait;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Connector<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Connector
  *
  * @group  queue
  */

--- a/tests/Failed/RabbitQueueFailedJobProviderTest.php
+++ b/tests/Failed/RabbitQueueFailedJobProviderTest.php
@@ -13,7 +13,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Failed\RabbitQueueFailedJobProvider;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTrait;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Failed\RabbitQueueFailedJobProvider<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Failed\RabbitQueueFailedJobProvider
  *
  * @group usesExternalServices
  */
@@ -61,7 +61,7 @@ class RabbitQueueFailedJobProviderTest extends AbstractTestCase
         $message = $this->getLastMessage();
 
         $this->assertSame($connection_name, $message->getProperty('job-connection-name'));
-        $this->assertInternalType('numeric', $message->getProperty('job-failed-at'));
+        $this->assertIsNumeric($message->getProperty('job-failed-at'));
         $this->assertSame($queue_name, $message->getProperty('job-queue-name'));
         $this->assertSame((string) $exception, $message->getProperty('job-exception'));
         $this->assertSame($message_body, $message->getBody());
@@ -78,10 +78,10 @@ class RabbitQueueFailedJobProviderTest extends AbstractTestCase
      */
     public function testGenerateMessageId(): void
     {
-        $this->assertInternalType('numeric', $this->provider::generateMessageId('foo'));
-        $this->assertInternalType('numeric', $this->provider::generateMessageId(['foo']));
-        $this->assertInternalType('numeric', $this->provider::generateMessageId(['foo', false]));
-        $this->assertInternalType('numeric', $this->provider::generateMessageId(['foo', false], 123));
+        $this->assertIsNumeric($this->provider::generateMessageId('foo'));
+        $this->assertIsNumeric($this->provider::generateMessageId(['foo']));
+        $this->assertIsNumeric($this->provider::generateMessageId(['foo', false]));
+        $this->assertIsNumeric($this->provider::generateMessageId(['foo', false], 123));
     }
 
     /**

--- a/tests/Feature/QueueWorkerTest.php
+++ b/tests/Feature/QueueWorkerTest.php
@@ -16,6 +16,8 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\Stubs\PrioritizedQueueJobWithState;
 /**
  * @group feature
  * @group usesExternalServices
+ *
+ * @coversNothing
  */
 class QueueWorkerTest extends AbstractFeatureTest
 {
@@ -38,9 +40,9 @@ class QueueWorkerTest extends AbstractFeatureTest
         $job_class_safe = \preg_quote(SimpleQueueJob::class, '/');
 
         $this->assertEmpty($process_info['stderr']);
-        $this->assertRegExp('~^\d{2}\:\d{2}\:\d{2}\.\d{3}.+start.+$~im', $output[0] ?? '', $output->getAsPlaintText());
-        $this->assertRegExp("~^.+processing.+{$job_class_safe}.?$~im", $output[1] ?? '', $output->getAsPlaintText());
-        $this->assertRegExp("~^.+processed.+{$job_class_safe}.?$~im", $output[2] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression('~^\d{2}\:\d{2}\:\d{2}\.\d{3}.+start.+$~im', $output[0] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression("~^.+processing.+{$job_class_safe}.?$~im", $output[1] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression("~^.+processed.+{$job_class_safe}.?$~im", $output[2] ?? '', $output->getAsPlaintText());
         $this->assertSame(1, Sharer::get(SimpleQueueJob::class . '-handled'));
     }
 
@@ -90,7 +92,7 @@ class QueueWorkerTest extends AbstractFeatureTest
         $output = $process_info['stdout'];
 
         // Should be processed FIRST
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '~' . \preg_quote(PrioritizedQueueJob::class, '/') . '$~i',
             $output[1] ?? '',
             $output->getAsPlaintText()
@@ -154,7 +156,7 @@ class QueueWorkerTest extends AbstractFeatureTest
         /** @var CommandOutput $output */
         $output = $process_info['stdout'];
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "~^.+failed.+{$failed_job_id}.+pushed\sback.+$~im",
             $output[0] ?? '',
             $output->getAsPlaintText()
@@ -247,7 +249,7 @@ class QueueWorkerTest extends AbstractFeatureTest
 
         $when = Sharer::get(SimpleQueueJob::class . '-when');
 
-        $this->assertEquals($this->now + $delay, $when, 'Jobs processed with wrong delay', 1);
+        $this->assertEqualsWithDelta($this->now + $delay, $when, 1, 'Jobs processed with wrong delay');
     }
 
     /**
@@ -269,7 +271,7 @@ class QueueWorkerTest extends AbstractFeatureTest
 
         $when = Sharer::get(QueueJobWithDelay::class . '-when');
 
-        $this->assertEquals($this->now + $job->delay, $when, 'Jobs processed with wrong delay', 1);
+        $this->assertEqualsWithDelta($this->now + $job->delay, $when, 1, 'Jobs processed with wrong delay');
     }
 
     /**
@@ -294,7 +296,7 @@ class QueueWorkerTest extends AbstractFeatureTest
 
         $when = Sharer::get(SimpleQueueJob::class . '-when');
 
-        $this->assertEquals($this->now, $when, 'Jobs processed with wrong delay', 1);
+        $this->assertEqualsWithDelta($this->now, $when, 1, 'Jobs processed with wrong delay');
     }
 
     /**
@@ -391,7 +393,12 @@ class QueueWorkerTest extends AbstractFeatureTest
 
         $when = Sharer::get(QueueJobWithSavedStateDelay::class . '-when');
 
-        $this->assertEquals((new \DateTime)->getTimestamp(), $when + $delay, 'Jobs processed with wrong delay', 1);
+        $this->assertEqualsWithDelta(
+            (new \DateTime)->getTimestamp(),
+            $when + $delay,
+            1,
+            'Jobs processed with wrong delay'
+        );
     }
 
     /**
@@ -420,9 +427,9 @@ class QueueWorkerTest extends AbstractFeatureTest
         $output            = $process_info['stdout'];
         $priority_job_name = \preg_quote(PrioritizedQueueJobWithState::class, '/');
 
-        $this->assertRegExp('~^\d{2}\:\d{2}\:\d{2}\.\d{3}.+start.+$~im', $output[0] ?? '', $output->getAsPlaintText());
-        $this->assertRegExp("~^.+processing.+{$priority_job_name}.?$~im", $output[1] ?? '', $output->getAsPlaintText());
-        $this->assertRegExp("~^.+processed.+{$priority_job_name}.?$~im", $output[2] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression('~^\d{2}\:\d{2}\:\d{2}\.\d{3}.+start.+$~im', $output[0] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression("~^.+processing.+{$priority_job_name}.?$~im", $output[1] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression("~^.+processed.+{$priority_job_name}.?$~im", $output[2] ?? '', $output->getAsPlaintText());
 
         $this->assertEquals(1, Sharer::get(PrioritizedQueueJobWithState::class . '-handled'));
         $this->assertEquals(

--- a/tests/HasPriorityTraitTest.php
+++ b/tests/HasPriorityTraitTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitLaravelQueue\Tests;
 use AvtoDev\AmqpRabbitLaravelQueue\HasPriorityTrait;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\HasPriorityTrait<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\HasPriorityTrait
  */
 class HasPriorityTraitTest extends AbstractTestCase
 {

--- a/tests/JobStateTest.php
+++ b/tests/JobStateTest.php
@@ -10,7 +10,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\JobState;
 use AvtoDev\AmqpRabbitLaravelQueue\JobStateInterface;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\JobState<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\JobState
  */
 class JobStateTest extends AbstractTestCase
 {
@@ -110,7 +110,7 @@ class JobStateTest extends AbstractTestCase
     public function testPutThrowsAnExceptionWhenPassedCallable(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('~Wrong value passed~i');
+        $this->expectErrorMessageMatches('~Wrong value passed~i');
 
         $this->instance->put('foo', function (): void {
         });
@@ -124,7 +124,7 @@ class JobStateTest extends AbstractTestCase
     public function testPutThrowsAnExceptionWhenPassedResource(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('~Wrong value passed~i');
+        $this->expectExceptionMessageMatches('~Wrong value passed~i');
 
         $this->instance->put('foo', \tmpfile());
     }

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -18,7 +18,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\JobStateInterface;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTrait;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Job<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Job
  *
  * @group  queue
  * @group  usesExternalServices

--- a/tests/Listeners/BindJobStateListenerTest.php
+++ b/tests/Listeners/BindJobStateListenerTest.php
@@ -14,7 +14,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTra
 /**
  * @group  listeners
  *
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Listeners\BindJobStateListener<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Listeners\BindJobStateListener
  * @group  usesExternalServices
  */
 class BindJobStateListenerTest extends AbstractExchangeListenerTestCase

--- a/tests/Listeners/CreateExchangeBindTest.php
+++ b/tests/Listeners/CreateExchangeBindTest.php
@@ -13,7 +13,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTra
 /**
  * @group listeners
  *
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Listeners\CreateExchangeBind<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Listeners\CreateExchangeBind
  * @group  usesExternalServices
  */
 class CreateExchangeBindTest extends AbstractExchangeListenerTestCase

--- a/tests/Listeners/RemoveExchangeBindTest.php
+++ b/tests/Listeners/RemoveExchangeBindTest.php
@@ -13,7 +13,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTra
 /**
  * @group listeners
  *
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Listeners\RemoveExchangeBind<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Listeners\RemoveExchangeBind
  * @group  usesExternalServices
  */
 class RemoveExchangeBindTest extends AbstractExchangeListenerTestCase

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -17,7 +17,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\Stubs\PrioritizedQueueJob;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTrait;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Queue<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Queue
  *
  * @group  queue
  * @group  usesExternalServices
@@ -598,7 +598,7 @@ class QueueTest extends AbstractTestCase
      */
     protected function assertCommonMessageProperties(Message $message, int $allowed_timestamp_delta = 500): void
     {
-        $this->assertRegExp('~job\-[a-zA-Z0-9]{6,}~', $message->getHeader('message_id'));
+        $this->assertMatchesRegularExpression('~job\-[a-zA-Z0-9]{6,}~', $message->getHeader('message_id'));
 
         $timestamp         = $message->getHeader('timestamp');
         $current_timestamp = (new DateTime)->getTimestamp();

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -8,8 +8,8 @@ use Illuminate\Queue\QueueManager;
 use AvtoDev\AmqpRabbitLaravelQueue\Worker;
 use Illuminate\Queue\Events\JobProcessing;
 use AvtoDev\AmqpRabbitLaravelQueue\Connector;
-use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\WorkCommand;
+use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
 use AvtoDev\AmqpRabbitLaravelQueue\Commands\JobMakeCommand;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreated;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleting;
@@ -92,10 +92,7 @@ class ServiceProviderTest extends AbstractTestCase
         $this->config()->offsetUnset('queue.failed.connection');
         $this->config()->offsetUnset('queue.failed.queue_id');
 
-        // Laravel 8 changed default value to new database-uuid driver
-        $this->config()->set('queue.failed.driver', 'database');
-
-        $this->assertInstanceOf(DatabaseFailedJobProvider::class, $this->app->make('queue.failer'));
+        $this->assertInstanceOf(DatabaseUuidFailedJobProvider::class, $this->app->make('queue.failer'));
     }
 
     /**

--- a/tests/WithJobStateTraitTest.php
+++ b/tests/WithJobStateTraitTest.php
@@ -15,6 +15,8 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTra
 
 /**
  * @group  usesExternalServices
+ *
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\WithJobStateTrait
  */
 class WithJobStateTraitTest extends AbstractTestCase
 {
@@ -70,7 +72,7 @@ class WithJobStateTraitTest extends AbstractTestCase
      *
      * @return void
      */
-    public function testGetStateWithoutNeededInstanceProperty()
+    public function testGetStateWithoutNeededInstanceProperty(): void
     {
         $this->expectException(RuntimeException::class);
         $object = new class {

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -21,7 +21,7 @@ use Illuminate\Queue\Connectors\ConnectorInterface as IlluminateQueueConnector;
 use AvtoDev\AmqpRabbitLaravelQueue\Tests\Traits\WithTemporaryRabbitConnectionTrait;
 
 /**
- * @covers \AvtoDev\AmqpRabbitLaravelQueue\Worker<extended>
+ * @covers \AvtoDev\AmqpRabbitLaravelQueue\Worker
  *
  * @group  queue
  * @group  usesExternalServices


### PR DESCRIPTION
## Description

### Changed

- Minimal required PHP version now is `7.3`
- Minimal `symfony/*` version now is `5.1`
- Minimal `illuminate/*` package versions now is `8.0`
- Minimal `laravel/laravel` package versions now is `8.0`
- Minimal `phpunit/phpunit` package versions now is `9.3`
- Minimal `avto-dev/amqp-rabbit-manager` package versions now is `2.3`
- Version of `php` in docker container updated up to `7.3`
- Version of `composer` in docker container updated up to `2.0.12`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
