### PR TITLE
Add support php8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Support PHP `8.x`
+- Support Laravel `9.x`
+
+### Changed
+
+- XDebug version up to `3.1.5`
+- Package `alanxz/rabbitmq-c` up to `0.11`
+- Package `pdezwart/php-amqp` up to `1.11`
+
 ## v2.5.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:7.3-alpine
+FROM php:8.0-alpine
 
 ENV \
     # <https://github.com/alanxz/rabbitmq-c>
-    RABBITMQ_VERSION="0.10.0" \
+    RABBITMQ_VERSION="0.11.0" \
     # ext-amqp <https://github.com/pdezwart/php-amqp>
-    PHP_AMQP_VERSION="1.10.2" \
+    PHP_AMQP_VERSION="1.11.0" \
     COMPOSER_HOME="/tmp/composer"
 
 COPY --from=composer:2.0.12 /usr/bin/composer /usr/bin/composer
@@ -26,7 +26,7 @@ RUN set -x \
     # workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.1 1>/dev/null \
+    && pecl install xdebug-3.1.5 1>/dev/null \
     # this c-library is required for 'php-amqp'
     && ( git clone --branch v${RABBITMQ_VERSION} https://github.com/alanxz/rabbitmq-c.git /tmp/rabbitmq \
         && cd /tmp/rabbitmq \

--- a/Dockerfile.rabbitmq
+++ b/Dockerfile.rabbitmq
@@ -1,17 +1,16 @@
 FROM alpine:latest as downloader
 
-ENV PLUGIN_VERSION="20171201"
+ENV PLUGIN_VERSION="3.8.0"
 
 RUN set -xe \
     && apk add --no-cache curl unzip \
     && mkdir /tmp/rabbitmq_delayed_message_exchange \
-    && curl -L https://dl.bintray.com/rabbitmq/community-plugins/3.7.x/rabbitmq_delayed_message_exchange/rabbitmq_delayed_message_exchange-${PLUGIN_VERSION}-3.7.x.zip -o /tmp/plugin.zip \
-    && unzip /tmp/plugin.zip -d /tmp/plugin \
-    && ls -l /tmp/plugin
+    && curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v${PLUGIN_VERSION}/rabbitmq_delayed_message_exchange-${PLUGIN_VERSION}.ez -o /tmp/plugin.ez \
+    && ls -l /tmp/*.ez
 
 FROM rabbitmq:3.7-management-alpine
 
-COPY --from=downloader /tmp/plugin/*.ez /opt/rabbitmq/plugins/
+COPY --from=downloader /tmp/plugin.ez /opt/rabbitmq/plugins/
 
 RUN set -x \
     && rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange \

--- a/composer.json
+++ b/composer.json
@@ -17,21 +17,21 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "ext-amqp": "*",
         "ext-json": "*",
-        "illuminate/support": "^8.0",
-        "illuminate/queue": "^8.0",
-        "illuminate/container": "^8.0",
-        "illuminate/contracts": "^8.0",
+        "illuminate/support": "^8.0 || ^9.0",
+        "illuminate/queue": "^8.0 || ^9.0",
+        "illuminate/container": "^8.0 || ^9.0",
+        "illuminate/contracts": "^8.0 || ^9.0",
         "symfony/console": "^5.1",
-        "avto-dev/amqp-rabbit-manager": "^2.3"
+        "avto-dev/amqp-rabbit-manager": "dev-support-php-8"
     },
     "require-dev": {
-        "laravel/laravel": "^8.0",
-        "mockery/mockery": "^1.3",
+        "laravel/laravel": "^8.0 || ^9.0",
+        "mockery/mockery": "^1.3.2",
         "symfony/process": "^5.1",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^0.12.34",
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {

--- a/src/InteractsWithJobsTrait.php
+++ b/src/InteractsWithJobsTrait.php
@@ -62,7 +62,7 @@ trait InteractsWithJobsTrait
      *
      * @return string
      */
-    protected function generateMessageId(string $prefix = '', ...$arguments): string
+    protected function generateMessageId(string $prefix, ...$arguments): string
     {
         return $prefix . Str::substr(\sha1(\serialize($arguments)), 0, 8);
     }


### PR DESCRIPTION
## Description

### Added

- Support PHP `8.x`
- Support Laravel `9.x`

### Changed

- XDebug version up to `3.1.5`
- Package `alanxz/rabbitmq-c` up to `0.11`
- Package `pdezwart/php-amqp` up to `1.11`

Fixes #21 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

