### PR TITLE
Draft: Change maximum `symfony/console` version to 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+## Changed
+
+- Maximal `symfony/console` package versions now is `6.*`
+- 
 ## v2.6.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ## Changed
 
 - Maximal `symfony/console` package versions now is `6.*`
-- 
+
 ## v2.6.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/queue": "^8.0 || ^9.0",
         "illuminate/container": "^8.0 || ^9.0",
         "illuminate/contracts": "^8.0 || ^9.0",
-        "symfony/console": "^5.1",
+        "symfony/console": "^5.1 || ^6.0",
         "avto-dev/amqp-rabbit-manager": "^2.6"
     },
     "require-dev": {


### PR DESCRIPTION
## Description

## Changed

- Maximal `symfony/console` package versions now is `6.*`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
