### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         php: ['8.0', '8.1', '8.2']        
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -51,12 +51,12 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
@@ -83,7 +83,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         if: matrix.coverage == 'yes'
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -96,7 +96,7 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support Laravel `10.x`
+- Support PHPUnit `v10`
+
+### Changed
+
+- Minimal require PHP version now is `8.0.2`
+- Composer version up to `2.6.5`
+- RabbitMQ version up to `0.13.0`
+- Package `mockery/mockery` up to `^1.6`
+- Package `phpstan/phpstan` up to `^1.10`
+- Package `avto-dev/amqp-rabbit-manager` up to `^2.9`
+
 ## v2.7.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,18 @@ FROM php:8.0-alpine
 
 ENV \
     # <https://github.com/alanxz/rabbitmq-c>
-    RABBITMQ_VERSION="0.11.0" \
+    RABBITMQ_VERSION="0.13.0" \
     # ext-amqp <https://github.com/pdezwart/php-amqp>
     PHP_AMQP_VERSION="1.11.0" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.5.1 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6.5 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps \
         linux-headers \
-        openssl-dev \        
+        openssl-dev \
         autoconf \
         pkgconf \
         cmake \

--- a/composer.json
+++ b/composer.json
@@ -17,22 +17,22 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0.2",
         "ext-amqp": "*",
         "ext-json": "*",
-        "illuminate/support": "^9.0",
-        "illuminate/queue": "^9.0",
-        "illuminate/container": "^9.0",
-        "illuminate/contracts": "^9.0",
+        "illuminate/support": "^9.0 || ^10.0",
+        "illuminate/queue": "^9.0 || ^10.0",
+        "illuminate/container": "^9.0 || ^10.0",
+        "illuminate/contracts": "^9.0 || ^10.0",
         "symfony/console": "^6.0",
-        "avto-dev/amqp-rabbit-manager": "^2.8"
+        "avto-dev/amqp-rabbit-manager": "^2.9"
     },
     "require-dev": {
-        "laravel/laravel": "^9.0",
-        "mockery/mockery": "^1.5.1",
+        "laravel/laravel": "^9.0 || ^10.0",
+        "mockery/mockery": "^1.6",
         "symfony/process": "^6.0",
-        "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit": "^9.6",
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^9.6 || ^10.4",
         "nesbot/carbon": "^2.66"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          colors="true"
-         convertErrorsToExceptions="true"
          convertNoticesToExceptions="false"
-         convertWarningsToExceptions="true"
-         forceCoversAnnotation="true"
-         processIsolation="false"
-         stopOnFailure="false">
+         forceCoversAnnotation="true">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">./src</directory>

--- a/tests/Feature/AbstractFeatureTestCase.php
+++ b/tests/Feature/AbstractFeatureTestCase.php
@@ -12,7 +12,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\AbstractTestCase;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use AvtoDev\AmqpRabbitLaravelQueue\Failed\RabbitQueueFailedJobProvider;
 
-abstract class AbstractFeatureTest extends AbstractTestCase
+abstract class AbstractFeatureTestCase extends AbstractTestCase
 {
     /**
      * @var RabbitQueueFailedJobProvider

--- a/tests/Feature/QueueWorkerTest.php
+++ b/tests/Feature/QueueWorkerTest.php
@@ -19,7 +19,7 @@ use AvtoDev\AmqpRabbitLaravelQueue\Tests\Stubs\PrioritizedQueueJobWithState;
  *
  * @coversNothing
  */
-class QueueWorkerTest extends AbstractFeatureTest
+class QueueWorkerTest extends AbstractFeatureTestCase
 {
     /**
      * @medium

--- a/tests/JobStateTest.php
+++ b/tests/JobStateTest.php
@@ -110,7 +110,7 @@ class JobStateTest extends AbstractTestCase
     public function testPutThrowsAnExceptionWhenPassedCallable(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessageMatches('~Wrong value passed~i');
+        $this->expectExceptionMessageMatches('~Wrong value passed~i');
 
         $this->instance->put('foo', function (): void {
         });

--- a/tests/Listeners/CreateExchangeBindTest.php
+++ b/tests/Listeners/CreateExchangeBindTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace AvtoDev\AmqpRabbitLaravelQueue\Tests\Listeners;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Event;
 use AvtoDev\AmqpRabbitLaravelQueue\Connector;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreated;
 use AvtoDev\AmqpRabbitLaravelQueue\Listeners\CreateExchangeBind;
@@ -37,11 +38,13 @@ class CreateExchangeBindTest extends AbstractExchangeListenerTestCase
      */
     public function testHandle(): void
     {
-        $this->doesntExpectEvents('queue.delayed-jobs.exchange.bind');
+        Event::fake();
 
         $event = new ExchangeCreated($this->temp_rabbit_connection, $this->temp_rabbit_exchange, Str::random());
 
         $this->listener->handle($event);
+
+        Event::assertNotDispatched('queue.delayed-jobs.exchange.bind');
     }
 
     /**
@@ -51,7 +54,7 @@ class CreateExchangeBindTest extends AbstractExchangeListenerTestCase
      */
     public function testHandleFired(): void
     {
-        $this->expectsEvents('queue.delayed-jobs.exchange.bind');
+        Event::fake();
 
         $this->config()->set('queue.connections', [
             'foo' => [
@@ -70,5 +73,7 @@ class CreateExchangeBindTest extends AbstractExchangeListenerTestCase
         );
 
         $this->listener->handle($event);
+
+        Event::assertDispatched('queue.delayed-jobs.exchange.bind');
     }
 }

--- a/tests/Listeners/RemoveExchangeBindTest.php
+++ b/tests/Listeners/RemoveExchangeBindTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace AvtoDev\AmqpRabbitLaravelQueue\Tests\Listeners;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Event;
 use AvtoDev\AmqpRabbitLaravelQueue\Connector;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleting;
 use AvtoDev\AmqpRabbitLaravelQueue\Listeners\RemoveExchangeBind;
@@ -37,11 +38,13 @@ class RemoveExchangeBindTest extends AbstractExchangeListenerTestCase
      */
     public function testHandle(): void
     {
-        $this->doesntExpectEvents('queue.delayed-jobs.exchange.unbind');
+        Event::fake();
 
         $event = new ExchangeDeleting($this->temp_rabbit_connection, $this->temp_rabbit_exchange, Str::random());
 
         $this->listener->handle($event);
+
+        Event::assertNotDispatched('queue.delayed-jobs.exchange.unbind');
     }
 
     /**
@@ -51,7 +54,7 @@ class RemoveExchangeBindTest extends AbstractExchangeListenerTestCase
      */
     public function testHandleFired(): void
     {
-        $this->expectsEvents('queue.delayed-jobs.exchange.unbind');
+        Event::fake();
 
         $this->config()->set('queue.connections', [
             'foo' => [
@@ -70,5 +73,7 @@ class RemoveExchangeBindTest extends AbstractExchangeListenerTestCase
         );
 
         $this->listener->handle($event);
+
+        Event::assertDispatched('queue.delayed-jobs.exchange.unbind');
     }
 }


### PR DESCRIPTION
## Description

Laravel 10 and PHPUnit 10 support

Fixes #32

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Added

- Support Laravel `10.x`
- Support PHPUnit `v10`

### Changed

- Minimal require PHP version now is `8.0.2`
- Composer version up to `2.6.5`
- RabbitMQ version up to `0.13.0`
- Package `mockery/mockery` up to `^1.6`
- Package `phpstan/phpstan` up to `^1.10`
- Package `avto-dev/amqp-rabbit-manager` up to `^2.9`
