### PR TITLE
Fix type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Fixed
+
+- Type mismatch after the release of Laravel `v11.26.0`
+
 ## v2.9.0
 
 ### Added

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,5 @@
 parameters:
   level: 'max'
   reportUnmatchedIgnoredErrors: false
-  checkGenericClassInNonGenericObjectType: false
   paths:
     - src

--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace AvtoDev\AmqpRabbitLaravelQueue\Commands;
 
-use Illuminate\Contracts\Queue\Job;
 use AvtoDev\AmqpRabbitLaravelQueue\Worker;
 use Illuminate\Contracts\Cache\Repository as Cache;
 
@@ -33,76 +32,7 @@ class WorkCommand extends \Illuminate\Queue\Console\WorkCommand
             '~(--sleep.*)}~', '$1 <options=bold>(not used)</> }', $this->signature
         );
 
-        // Constructor signature in parent class changed since 6.0:
-        // For ~5.5 one argument:
-        // - https://github.com/laravel/framework/blob/v5.5.0/src/Illuminate/Queue/Console/WorkCommand.php#L53
-        // - https://github.com/laravel/framework/blob/v5.6.0/src/Illuminate/Queue/Console/WorkCommand.php#L53
-        // - https://github.com/laravel/framework/blob/v5.7.0/src/Illuminate/Queue/Console/WorkCommand.php#L53
-        // - https://github.com/laravel/framework/blob/v5.8.0/src/Illuminate/Queue/Console/WorkCommand.php#L54
-        // Since ^6.0 - two arguments:
-        // - https://github.com/laravel/framework/blob/v6.0.0/src/Illuminate/Queue/Console/WorkCommand.php#L63
-        // - https://github.com/laravel/framework/blob/v7.0.0/src/Illuminate/Queue/Console/WorkCommand.php#L62
-        //        parent::{'__construct'}(...[$worker, $cache]);
-        parent::__construct(...[$worker, $cache]);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @codeCoverageIgnore
-     */
-    public function line($string, $style = null, $verbosity = null): void
-    {
-        $time = (new \DateTime)->format('H:i:s.v');
-
-        $styled = $style
-            ? "<$style>$string</$style>"
-            : $string;
-
-        $this->output->writeln("<fg=white>{$time}</> {$styled}", $this->parseVerbosity($verbosity));
-    }
-
-    /**
-     * Write the status output for the queue worker.
-     *
-     * @param Job $job
-     * @param  string  $status
-     * @return void
-     *
-     * @codeCoverageIgnore
-     */
-    protected function writeOutput(Job $job, $status): void
-    {
-        switch ($status) {
-            case 'starting':
-                $this->writeStatus($job, 'Processing', 'comment');
-                break;
-            case 'success':
-                $this->writeStatus($job, 'Processed', 'info');
-                break;
-            case 'failed':
-                $this->writeStatus($job, 'Failed', 'error');
-                break;
-        }
-    }
-
-    /**
-     * Format the status output for the queue worker.
-     *
-     * @param Job $job
-     * @param  string  $status
-     * @param  string  $type
-     * @return void
-     *
-     * @codeCoverageIgnore
-     */
-    protected function writeStatus(Job $job, $status, $type): void
-    {
-        $this->line(sprintf(
-            "<{$type}>[%s] %s</{$type}> %s",
-            $job->getJobId(),
-            \str_pad("{$status}:", 11), $job->resolveName()
-        ));
+        parent::__construct($worker, $cache);
     }
 
     /**

--- a/src/JobState.php
+++ b/src/JobState.php
@@ -8,6 +8,13 @@ use Closure;
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
 
+/**
+ * @template TKey of array-key
+ *
+ * @template TValue
+ *
+ * @extends Collection<TKey, TValue>
+ */
 class JobState extends Collection implements JobStateInterface
 {
     /**
@@ -52,5 +59,23 @@ class JobState extends Collection implements JobStateInterface
         }
 
         return parent::put($key, $value);
+    }
+
+    /**
+     * @return array<TKey, TValue>
+     */
+    public function __serialize(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * @param array<TKey, TValue> $data
+     *
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->items = $data;
     }
 }

--- a/tests/Feature/QueueWorkerTest.php
+++ b/tests/Feature/QueueWorkerTest.php
@@ -40,9 +40,8 @@ class QueueWorkerTest extends AbstractFeatureTestCase
         $job_class_safe = \preg_quote(SimpleQueueJob::class, '/');
 
         $this->assertEmpty($process_info['stderr']);
-        $this->assertMatchesRegularExpression('~^\d{2}\:\d{2}\:\d{2}\.\d{3}.+start.+$~im', $output[0] ?? '', $output->getAsPlaintText());
-        $this->assertMatchesRegularExpression("~^.+processing.+{$job_class_safe}.?$~im", $output[1] ?? '', $output->getAsPlaintText());
-        $this->assertMatchesRegularExpression("~^.+processed.+{$job_class_safe}.?$~im", $output[2] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression('~^.+worker started.+$~im', $output[0] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression("~^.+{$job_class_safe}.?$~im", $output[1] ?? '', $output->getAsPlaintText());
         $this->assertSame(1, Sharer::get(SimpleQueueJob::class . '-handled'));
     }
 
@@ -427,9 +426,8 @@ class QueueWorkerTest extends AbstractFeatureTestCase
         $output            = $process_info['stdout'];
         $priority_job_name = \preg_quote(PrioritizedQueueJobWithState::class, '/');
 
-        $this->assertMatchesRegularExpression('~^\d{2}\:\d{2}\:\d{2}\.\d{3}.+start.+$~im', $output[0] ?? '', $output->getAsPlaintText());
-        $this->assertMatchesRegularExpression("~^.+processing.+{$priority_job_name}.?$~im", $output[1] ?? '', $output->getAsPlaintText());
-        $this->assertMatchesRegularExpression("~^.+processed.+{$priority_job_name}.?$~im", $output[2] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression('~^.+worker started.+$~im', $output[0] ?? '', $output->getAsPlaintText());
+        $this->assertMatchesRegularExpression("~^.+{$priority_job_name}.?$~im", $output[1] ?? '', $output->getAsPlaintText());
 
         $this->assertEquals(1, Sharer::get(PrioritizedQueueJobWithState::class . '-handled'));
         $this->assertEquals(


### PR DESCRIPTION
## Description

- Fix the mismatch of the method signature

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Fixed

- Type mismatch after the release of Laravel `v11.26.0`
