### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,9 +28,9 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
         include:
-          - php: '8.1'
+          - php: '8.2'
             setup: [ basic, lowest ]
             coverage: no
             laravel: '^10.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `12.x` support
+- Using `docker` with `compose` plugin instead of `docker-compose` for test environment
+
+### Changed
+
+- Minimal require PHP version now is `8.2`
+- Version of `composer` in docker container updated up to `2.8.9`
+- Updated dev dependencies
+
 ## v2.9.1
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV \
     PHP_AMQP_VERSION="1.11.0" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.7.4 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.8.9 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 # Makefile readme (ru): <http://linux.yaroslavl.ru/docs/prog/gnu_make_3-79_russian_manual.html>
 # Makefile readme (en): <https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents>
 
-dc_bin := $(shell command -v docker-compose 2> /dev/null)
-
 SHELL = /bin/sh
 RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
 
@@ -16,31 +14,31 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	$(dc_bin) build
+	docker compose build
 
 install: clean ## Install stable php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction
+	docker compose run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction
 
 latest: clean ## Install latest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --prefer-dist --prefer-stable
+	docker compose run $(RUN_APP_ARGS) composer update -n --ansi --prefer-dist --prefer-stable
 
 lowest: clean ## Install lowest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --prefer-dist --prefer-lowest
+	docker compose run $(RUN_APP_ARGS) composer update -n --ansi --prefer-dist --prefer-lowest
 
 test: up ## Execute php tests and linters
-	$(dc_bin) run $(RUN_APP_ARGS) sh -c "sleep 5 && composer test"
+	docker compose run $(RUN_APP_ARGS) sh -c "sleep 5 && composer test"
 
 test-cover: up ## Execute php tests with coverage
-	$(dc_bin) run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer test-cover"'
+	docker compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer test-cover"'
 
 up: ## Start services
-	$(dc_bin) up -d
+	docker compose up -d
 
 down: ## Stop services
-	$(dc_bin) down
+	docker compose down
 
 shell: ## Start shell into container with php
-	$(dc_bin) run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" \
+	docker compose run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" \
     $(RUN_APP_ARGS) sh
 
 clean: ## Remove all dependencies and unimportant files

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ You should avoid to use next method _(broker does not guarantee operations order
 
 ### Testing
 
-For package testing we use `phpunit` framework and `docker-ce` + `docker-compose` as develop environment. So, just write into your terminal after repository cloning:
+For package testing we use `phpunit` framework and `docker` with `compose` plugin as develop environment. So, just write into your terminal after repository cloning:
 
 ```shell
 $ make build

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,18 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-amqp": "*",
         "ext-json": "*",
-        "illuminate/support": "^10.0 || ^11.0",
-        "illuminate/queue": "^10.0 || ^11.0",
-        "illuminate/container": "^10.0 || ^11.0",
-        "illuminate/contracts": "^10.0 || ^11.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/queue": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/container": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
         "symfony/console": "^6.0 || ^7.0",
         "avto-dev/amqp-rabbit-manager": "^2.10"
     },
     "require-dev": {
-        "laravel/laravel": "^10.0 || ^11.0",
+        "laravel/laravel": "^10.0 || ^11.0 || ^12.0",
         "mockery/mockery": "^1.6",
         "symfony/process": "^6.0 || ^7.0",
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
## Description

### Added

- Laravel `12.x` support
- Using `docker` with `compose` plugin instead of `docker-compose` for test environment

### Changed

- Minimal require PHP version now is `8.2`
- Version of `composer` in docker container updated up to `2.8.9`
- Updated dev dependencies

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
